### PR TITLE
add a opengl trap

### DIFF
--- a/basics/VAO_EBO
+++ b/basics/VAO_EBO
@@ -1,0 +1,21 @@
+When we bind VAO or EBO, then unbinding it after we never use them is a good practise.But we must be careful about the unbind order.
+
+This is wrong:
+glBindVertexArray(VAO)
+glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
+...
+glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+glBindVertexArray(0);
+...
+glBindVertexArray(VAO);
+glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);//crash
+
+This is correct:
+glBindVertexArray(VAO)
+glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
+...
+glBindVertexArray(0);
+glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+...
+glBindVertexArray(VAO);
+glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);//don't crash

--- a/basics/VAO_EBO.md
+++ b/basics/VAO_EBO.md
@@ -1,7 +1,7 @@
 When we bind VAO or EBO, then unbinding it after we never use them is a good practise.But we must be careful about the unbind order.
 
 This is wrong:
-glBindVertexArray(VAO)
+  glBindVertexArray(VAO)
 glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
 ...
 glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);

--- a/basics/VAO_EBO.md
+++ b/basics/VAO_EBO.md
@@ -1,21 +1,23 @@
 When we bind VAO or EBO, then unbinding it after we never use them is a good practise.But we must be careful about the unbind order.
 
-This is wrong:
-  glBindVertexArray(VAO)
-glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
-...
-glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-glBindVertexArray(0);
-...
-glBindVertexArray(VAO);
-glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);//crash
+This is wrong:  
 
-This is correct:
-glBindVertexArray(VAO)
-glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
-...
-glBindVertexArray(0);
-glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-...
-glBindVertexArray(VAO);
-glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);//don't crash
+    glBindVertexArray(VAO)  
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);  
+    ...  
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);  
+    glBindVertexArray(0);  
+    ...  
+    glBindVertexArray(VAO);  
+    glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);//crash  
+
+This is correct:  
+
+    glBindVertexArray(VAO)  
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);  
+    ...  
+    glBindVertexArray(0);  
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);  
+    ...  
+    glBindVertexArray(VAO);  
+    glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);//don't crash  


### PR DESCRIPTION
在使用opengl的过程中发现了一个VAO和EBO bind和unbind顺序之间的坑，但是VAO和VBO没有这样的坑
